### PR TITLE
Call initMonaco if monaco is already loaded using different method

### DIFF
--- a/projects/editor/src/lib/base-editor.ts
+++ b/projects/editor/src/lib/base-editor.ts
@@ -53,6 +53,7 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
       loadPromise = new Promise<void>((resolve: any) => {
         const baseUrl = this.config.baseUrl || "./assets";
         if (typeof ((<any>window).monaco) === 'object') {
+          this.initMonaco(this._options, this.insideNg);
           resolve();
           return;
         }


### PR DESCRIPTION
In my scenario I load `monaco-editor` using `monaco-editor-webpack-plugin` with `globalAPI: true`. `ngx-monaco-editor` correctly recognizes that the monaco is already loaded (`loadedMonaco` is set to true and `loadPromise` is resolved) but the first `BaseEditor` instance never calls `initMonaco`.