### PR TITLE
Added support for Electron

### DIFF
--- a/projects/editor/src/lib/config.ts
+++ b/projects/editor/src/lib/config.ts
@@ -4,6 +4,8 @@ export const NGX_MONACO_EDITOR_CONFIG = new InjectionToken('NGX_MONACO_EDITOR_CO
 
 export interface NgxMonacoEditorConfig {
   baseUrl?: string;
+  requireConfig?: { [key: string]: any; };
   defaultOptions?: { [key: string]: any; };
+  monacoRequire?: Function;
   onMonacoLoad?: Function;
 }


### PR DESCRIPTION
- Fixed issue where if aplication runs in Electron with nodeIntegration enabled this plugin assumes node's `require` as monaco editor's loader. 

- Renamed monaco loader so it wont override node's `require` in the same scenario.

- Exposed monaco loder's configuration in this plugins configuration in order to allow for easier making of workarounds for similar issues.  

- Added the option to directly provide monaco editor`s loader for the same reason.

- Updated README.md.