### PR TITLE
fix: README imports from ngx-monaco-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the glob to assets in `angular.json`
   "apps": [
     {
       "assets": [
-      { "glob": "**/*", "input": "node_modules/monaco-editor-v2", "output": "/assets/monaco/" }
+      { "glob": "**/*", "input": "node_modules/monaco-editor", "output": "/assets/monaco/" }
       ],
       ...
     }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the glob to assets in `angular.json`
   "apps": [
     {
       "assets": [
-      { "glob": "**/*", "input": "node_modules/monaco-editor", "output": "/assets/monaco/" }
+      { "glob": "**/*", "input": "node_modules/monaco-editor-v2", "output": "/assets/monaco/" }
       ],
       ...
     }
@@ -62,7 +62,7 @@ For Angular 6 and below, add the glob to assets in `.angular-cli.json` schema - 
 {
   "options":{
         {"assets": [
-          { "glob": "**/*", "input": "node_modules/ngx-monaco-editor/assets/monaco", "output": "./assets/monaco/" }
+          { "glob": "**/*", "input": "node_modules/ngx-monaco-editor-v2/assets/monaco", "output": "./assets/monaco/" }
 
         ],
         ...
@@ -190,7 +190,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor';
+import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor-v2';
 import { AppComponent } from './app.component';
 
 const monacoConfig: NgxMonacoEditorConfig = {
@@ -224,7 +224,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor';
+import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor-v2';
 import { AppComponent } from './app.component';
 
 export function onMonacoLoad() {
@@ -320,7 +320,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor';
+import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor-v2';
 import { AppComponent } from './app.component';
 
 const monacoConfig: NgxMonacoEditorConfig = {
@@ -381,7 +381,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor';
+import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor-v2';
 import { AppComponent } from './app.component';
 
 const monacoConfig: NgxMonacoEditorConfig = {


### PR DESCRIPTION
Examples in README now import from `ngx-monaco-editor-v2`.