### PR TITLE
Feat remove hard coded path to fetch js monaco editor from CDN

### DIFF
--- a/projects/editor-tester/src/app/app.config.ts
+++ b/projects/editor-tester/src/app/app.config.ts
@@ -43,6 +43,7 @@ export function onMonacoLoad() {
 }
 
 const monacoConfig: NgxMonacoEditorConfig = {
+  // You can pass cdn url here instead
   baseUrl: 'assets',
   defaultOptions: { scrollBeyondLastLine: false },
   onMonacoLoad

--- a/projects/editor/README.md
+++ b/projects/editor/README.md
@@ -195,7 +195,7 @@ import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor-v2'
 import { AppComponent } from './app.component';
 
 const monacoConfig: NgxMonacoEditorConfig = {
-  baseUrl: 'app-name/assets', // configure base path for monaco editor. Starting with version 8.0.0 it defaults to './assets'. Previous releases default to '/assets'
+  baseUrl: 'app-name/assets', // configure base path for monaco editor. Starting with version 8.0.0 it defaults to './assets'. Previous releases default to '/assets', or you can pass CDN url here
   defaultOptions: { scrollBeyondLastLine: false }, // pass default options to be used
   onMonacoLoad: () => { console.log((<any>window).monaco); } // here monaco object will be available as window.monaco use this function to extend monaco editor functionalities.
   requireConfig: { preferScriptTags: true } // allows to oweride configuration passed to monacos loader
@@ -266,7 +266,7 @@ export function onMonacoLoad() {
 }
 
 const monacoConfig: NgxMonacoEditorConfig = {
-  baseUrl: 'assets',
+  baseUrl: 'assets', // You can pass CDN url here instead 
   defaultOptions: { scrollBeyondLastLine: false },
   onMonacoLoad
 };
@@ -325,7 +325,7 @@ import { MonacoEditorModule, NgxMonacoEditorConfig } from 'ngx-monaco-editor-v2'
 import { AppComponent } from './app.component';
 
 const monacoConfig: NgxMonacoEditorConfig = {
-  baseUrl: 'assets', 
+  baseUrl: 'assets', // You can pass CDN url here instead 
   requireConfig: { preferScriptTags: true }
 };
 

--- a/projects/editor/src/lib/base-editor.ts
+++ b/projects/editor/src/lib/base-editor.ts
@@ -51,7 +51,11 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
     } else {
       loadedMonaco = true;
       loadPromise = new Promise<void>((resolve: any) => {
-        const baseUrl = this.config.baseUrl || "./assets";
+        let baseUrl = this.config.baseUrl;
+        // ensure backward compatibility
+        if (baseUrl === "assets" || !baseUrl) {
+          baseUrl = "./assets/monaco/min/vs";
+        }
         if (typeof ((<any>window).monaco) === 'object') {
           this.initMonaco(this._options, this.insideNg);
           resolve();
@@ -59,7 +63,7 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
         }
         const onGotAmdLoader: any = (require?: any) => {
           let usedRequire = require || (<any>window).require;
-          let requireConfig = { paths: { vs: `${baseUrl}/monaco/min/vs` } };
+          let requireConfig = { paths: { vs: `${baseUrl}` } };
           Object.assign(requireConfig, this.config.requireConfig || {});
 
           // Load monaco
@@ -79,12 +83,12 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
         } else if (!(<any>window).require) {
           const loaderScript: HTMLScriptElement = document.createElement('script');
           loaderScript.type = 'text/javascript';
-          loaderScript.src = `${baseUrl}/monaco/min/vs/loader.js`;
+          loaderScript.src = `${baseUrl}/loader.js`;
           loaderScript.addEventListener('load', () => { onGotAmdLoader(); });
           document.body.appendChild(loaderScript);
         // Load AMD loader without over-riding node's require
         } else if (!(<any>window).require.config) {
-            var src = `${baseUrl}/monaco/min/vs/loader.js`;
+            var src = `${baseUrl}/loader.js`;
 
             var loaderRequest = new XMLHttpRequest();
             loaderRequest.addEventListener("load", () => {


### PR DESCRIPTION
I ensured backward compatibility and added the possibility to completely choose where we fetch JS monaco editor file. It can be from a CDN. It's really helpful because monaco editor really increase the size of an application. 
Of course, I tested everything is ok and tried with this link : https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.49.0/min/vs/loader.js