### PR TITLE
Fix: use options object with defaults

### DIFF
--- a/projects/editor/src/lib/diff-editor.component.ts
+++ b/projects/editor/src/lib/diff-editor.component.ts
@@ -34,7 +34,7 @@ export class DiffEditorComponent extends BaseEditor {
     this._options = Object.assign({}, this.config.defaultOptions, options);
     if (this._editor) {
       this._editor.dispose();
-      this.initMonaco(options, this.insideNg);
+      this.initMonaco(this._options, this.insideNg);
     }
   }
 

--- a/projects/editor/src/lib/editor.component.ts
+++ b/projects/editor/src/lib/editor.component.ts
@@ -41,7 +41,7 @@ export class EditorComponent extends BaseEditor implements ControlValueAccessor 
     this._options = Object.assign({}, this.config.defaultOptions, options);
     if (this._editor) {
       this._editor.dispose();
-      this.initMonaco(options, this.insideNg);
+      this.initMonaco(this._options, this.insideNg);
     }
   }
 


### PR DESCRIPTION
If we register module with some default options, e.g.:
```ts
MonacoEditorModule.forRoot({defaultOptions: { theme: 'vs-dark' }})
```
and use component like:
```ts
<ngx-monaco-editor [options]="{readOnly: readOnlyFlag}"></ngx-monaco-editor>
```
upon first render the options will get merged, but on next rerenders it will just use `{readOnly: readOnlyFlag}` without default - so toggling `readOnlyFlag` will remove the `theme: vs-dark` option.

