### PR TITLE
Set editor to readOnly if disabled

### DIFF
--- a/projects/editor/src/lib/editor.component.ts
+++ b/projects/editor/src/lib/editor.component.ts
@@ -76,6 +76,10 @@ export class EditorComponent extends BaseEditor implements ControlValueAccessor 
     this.onTouched = fn;
   }
 
+  setDisabledState(disabled: boolean): void {
+    this.options.readOnly = disabled;
+  }
+
   protected initMonaco(options: any, insideNg: boolean): void {
 
     const hasModel = !!options.model;


### PR DESCRIPTION
Currently when using `ReactiveFormsModule` and binding a disabled `[formControl]=` the editor is still editable.
Implement `ControlValueAccessor`s `setDisabledState` to set `readOnly` config