### PR TITLE
Set editor to readOnly from model or config

### DIFF
--- a/projects/editor/src/lib/editor.component.ts
+++ b/projects/editor/src/lib/editor.component.ts
@@ -77,7 +77,7 @@ export class EditorComponent extends BaseEditor implements ControlValueAccessor 
   }
 
   setDisabledState(disabled: boolean): void {
-    this.options.readOnly = disabled;
+    this.options.readOnly = disabled || this._options.readOnly;
   }
 
   protected initMonaco(options: any, insideNg: boolean): void {


### PR DESCRIPTION
Followup to #36, config was wrongly irgnored.
If either config has `readOnly: true` or `[ngMode]="myVar" disabled` is set, set editor to readonly